### PR TITLE
blocked - Issue/1280 news channel

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ChannelType.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ChannelType.cs
@@ -12,6 +12,8 @@ namespace Discord
         /// <summary> The channel is a group channel. </summary>
         Group = 3,
         /// <summary> The channel is a category channel. </summary>
-        Category = 4
+        Category = 4,
+        /// <summary> The channel is a news channel. </summary>
+        News = 5
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -38,5 +38,15 @@ namespace Discord
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 120].</exception>
         public Optional<int> SlowModeInterval { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the type of channel.
+        ///     Only setting to a <see cref="ChannelType.News"/> is supported.
+        /// </summary>
+        /// <remarks>
+        ///     Setting this value to a different type will change the type of channel that is associated with this Id.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown if the type of channel that is being set is not valid.</exception>
+        public Optional<ChannelType> Type { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
@@ -12,5 +12,7 @@ namespace Discord.API.Rest
         public Optional<bool> IsNsfw { get; set; }
         [JsonProperty("rate_limit_per_user")]
         public Optional<int> SlowModeInterval { get; set; }
+        [JsonProperty("type")]
+        public Optional<ChannelType> Type { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -377,6 +377,15 @@ namespace Discord.API
             Preconditions.NotNullOrEmpty(args.Name, nameof(args.Name));
             Preconditions.AtLeast(args.SlowModeInterval, 0, nameof(args.SlowModeInterval));
             Preconditions.AtMost(args.SlowModeInterval, 120, nameof(args.SlowModeInterval));
+            if (args.Type.IsSpecified)
+            {
+                // can only change Text/NewsChannel into a Text or News
+                var warn = "You may not change a Text or News channel into a Voice, Group, DM, or Category channel.";
+                Preconditions.NotEqual((uint)args.Type.Value, (uint)ChannelType.Voice, nameof(args.Type), warn);
+                Preconditions.NotEqual((uint)args.Type.Value, (uint)ChannelType.Group, nameof(args.Type), warn);
+                Preconditions.NotEqual((uint)args.Type.Value, (uint)ChannelType.DM, nameof(args.Type), warn);
+                Preconditions.NotEqual((uint)args.Type.Value, (uint)ChannelType.Category, nameof(args.Type), warn);
+            }
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(channelId: channelId);

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -46,6 +46,7 @@ namespace Discord.Rest
                 Topic = args.Topic,
                 IsNsfw = args.IsNsfw,
                 SlowModeInterval = args.SlowModeInterval,
+                Type = args.Type
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
@@ -23,6 +23,7 @@ namespace Discord.Rest
         {
             switch (model.Type)
             {
+                case ChannelType.News:
                 case ChannelType.Text:
                 case ChannelType.Voice:
                     return RestGuildChannel.Create(discord, new RestGuild(discord, model.GuildId.Value), model);

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -15,7 +15,7 @@ namespace Discord.Rest
         private ImmutableArray<Overwrite> _overwrites;
 
         /// <inheritdoc />
-        public IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
+        public virtual IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
 
         internal IGuild Guild { get; }
         /// <inheritdoc />
@@ -81,7 +81,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An overwrite object for the targeted user; <c>null</c> if none is set.
         /// </returns>
-        public OverwritePermissions? GetPermissionOverwrite(IUser user)
+        public virtual OverwritePermissions? GetPermissionOverwrite(IUser user)
         {
             for (int i = 0; i < _overwrites.Length; i++)
             {
@@ -98,7 +98,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An overwrite object for the targeted role; <c>null</c> if none is set.
         /// </returns>
-        public OverwritePermissions? GetPermissionOverwrite(IRole role)
+        public virtual OverwritePermissions? GetPermissionOverwrite(IRole role)
         {
             for (int i = 0; i < _overwrites.Length; i++)
             {
@@ -117,7 +117,7 @@ namespace Discord.Rest
         /// <returns>
         ///     A task representing the asynchronous permission operation for adding the specified permissions to the channel.
         /// </returns>
-        public async Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
+        public virtual async Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, user, permissions, options).ConfigureAwait(false);
             _overwrites = _overwrites.Add(new Overwrite(user.Id, PermissionTarget.User, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
@@ -131,7 +131,7 @@ namespace Discord.Rest
         /// <returns>
         ///     A task representing the asynchronous permission operation for adding the specified permissions to the channel.
         /// </returns>
-        public async Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
+        public virtual async Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, role, permissions, options).ConfigureAwait(false);
             _overwrites = _overwrites.Add(new Overwrite(role.Id, PermissionTarget.Role, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
@@ -145,7 +145,7 @@ namespace Discord.Rest
         /// <returns>
         ///     A task representing the asynchronous operation for removing the specified permissions from the channel.
         /// </returns>
-        public async Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
+        public virtual async Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, user, options).ConfigureAwait(false);
 
@@ -166,7 +166,7 @@ namespace Discord.Rest
         /// <returns>
         ///     A task representing the asynchronous operation for removing the specified permissions from the channel.
         /// </returns>
-        public async Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
+        public virtual async Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, role, options).ConfigureAwait(false);
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -35,8 +35,7 @@ namespace Discord.Rest
             switch (model.Type)
             {
                 case ChannelType.News:
-                    // TODO: create new RestNewsChannel
-                    throw new NotImplementedException();
+                    return RestNewsChannel.Create(discord, guild, model);
                 case ChannelType.Text:
                     return RestTextChannel.Create(discord, guild, model);
                 case ChannelType.Voice:

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -34,6 +34,9 @@ namespace Discord.Rest
         {
             switch (model.Type)
             {
+                case ChannelType.News:
+                    // TODO: create new RestNewsChannel
+                    throw new NotImplementedException();
                 case ChannelType.Text:
                     return RestTextChannel.Create(discord, guild, model);
                 case ChannelType.Voice:

--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -24,5 +24,30 @@ namespace Discord.Rest
             entity.Update(model);
             return entity;
         }
+        public override int SlowModeInterval => throw new NotSupportedException("News channels do not support Slow Mode.");
+        public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override OverwritePermissions? GetPermissionOverwrite(IRole role)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override OverwritePermissions? GetPermissionOverwrite(IUser user)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Model = Discord.API.Channel;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Represents a REST-based news channel in a guild that has the same properties as a <see cref="RestTextChannel"/>.
+    /// </summary>
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class RestNewsChannel : RestTextChannel
+    {
+        internal RestNewsChannel(BaseDiscordClient discord, IGuild guild, ulong id)
+            :base(discord, guild, id)
+        {
+        }
+        internal new static RestNewsChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
+        {
+            var entity = new RestNewsChannel(discord, guild, model.Id);
+            entity.Update(model);
+            return entity;
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -17,7 +17,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string Topic { get; private set; }
         /// <inheritdoc />
-        public int SlowModeInterval { get; private set; } 
+        public virtual int SlowModeInterval { get; private set; } 
         /// <inheritdoc />
         public ulong? CategoryId { get; private set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -48,6 +48,9 @@ namespace Discord.WebSocket
         {
             switch (model.Type)
             {
+                case ChannelType.News:
+                    // TODO: create new SocketNewsChannel
+                    throw new NotImplementedException();
                 case ChannelType.Text:
                     return SocketTextChannel.Create(guild, state, model);
                 case ChannelType.Voice:

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -58,7 +58,6 @@ namespace Discord.WebSocket
                 case ChannelType.Category:
                     return SocketCategoryChannel.Create(guild, state, model);
                 default:
-                    // TODO: Proper implementation for channel categories
                     return new SocketGuildChannel(guild.Discord, model.Id, guild);
             }
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -30,7 +30,7 @@ namespace Discord.WebSocket
         public int Position { get; private set; }        
 
         /// <inheritdoc />
-        public IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
+        public virtual IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
         /// <summary>
         ///     Gets a collection of users that are able to view the channel.
         /// </summary>
@@ -87,7 +87,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     An overwrite object for the targeted user; <c>null</c> if none is set.
         /// </returns>
-        public OverwritePermissions? GetPermissionOverwrite(IUser user)
+        public virtual OverwritePermissions? GetPermissionOverwrite(IUser user)
         {
             for (int i = 0; i < _overwrites.Length; i++)
             {
@@ -103,7 +103,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     An overwrite object for the targeted role; <c>null</c> if none is set.
         /// </returns>
-        public OverwritePermissions? GetPermissionOverwrite(IRole role)
+        public virtual OverwritePermissions? GetPermissionOverwrite(IRole role)
         {
             for (int i = 0; i < _overwrites.Length; i++)
             {
@@ -122,7 +122,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task representing the asynchronous permission operation for adding the specified permissions to the channel.
         /// </returns>
-        public async Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
+        public virtual async Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, user, permissions, options).ConfigureAwait(false);
             _overwrites = _overwrites.Add(new Overwrite(user.Id, PermissionTarget.User, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
@@ -137,7 +137,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task representing the asynchronous permission operation for adding the specified permissions to the channel.
         /// </returns>
-        public async Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
+        public virtual async Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, role, permissions, options).ConfigureAwait(false);
             _overwrites = _overwrites.Add(new Overwrite(role.Id, PermissionTarget.Role, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
@@ -150,7 +150,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task representing the asynchronous operation for removing the specified permissions from the channel.
         /// </returns>
-        public async Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
+        public virtual async Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, user, options).ConfigureAwait(false);
 
@@ -171,7 +171,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task representing the asynchronous operation for removing the specified permissions from the channel.
         /// </returns>
-        public async Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
+        public virtual async Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, role, options).ConfigureAwait(false);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -49,8 +49,7 @@ namespace Discord.WebSocket
             switch (model.Type)
             {
                 case ChannelType.News:
-                    // TODO: create new SocketNewsChannel
-                    throw new NotImplementedException();
+                    return SocketNewsChannel.Create(guild, state, model);
                 case ChannelType.Text:
                     return SocketTextChannel.Create(guild, state, model);
                 case ChannelType.Voice:

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using Model = Discord.API.Channel;
+
+namespace Discord.WebSocket
+{
+    /// <summary>
+    ///     Represents a WebSocket-based news channel in a guild that has the same properties as a <see cref="RestTextChannel"/>.
+    /// </summary>
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class SocketNewsChannel : SocketTextChannel
+    {
+        internal SocketNewsChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
+            :base(discord, id, guild)
+        {
+        }
+        internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
+        {
+            var entity = new SocketNewsChannel(guild.Discord, model.Id, guild);
+            entity.Update(state, model);
+            return entity;
+        }
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -13,7 +13,7 @@ namespace Discord.WebSocket
             :base(discord, id, guild)
         {
         }
-        internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
+        internal new static SocketNewsChannel Create(SocketGuild guild, ClientState state, Model model)
         {
             var entity = new SocketNewsChannel(guild.Discord, model.Id, guild);
             entity.Update(state, model);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -19,5 +19,6 @@ namespace Discord.WebSocket
             entity.Update(state, model);
             return entity;
         }
+        //TODO: Need to set custom channel properties for this type, as apparently it does not support slow mode or overwrites.
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Model = Discord.API.Channel;
 
 namespace Discord.WebSocket
@@ -19,6 +22,31 @@ namespace Discord.WebSocket
             entity.Update(state, model);
             return entity;
         }
-        //TODO: Need to set custom channel properties for this type, as apparently it does not support slow mode or overwrites.
+        public override int SlowModeInterval
+        {
+            get { throw new NotSupportedException("News channels do not support Slow Mode."); }
+        }
+        public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override IReadOnlyCollection<Overwrite> PermissionOverwrites
+            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        public override Task SyncPermissionsAsync(RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
+        public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
+        {
+            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -21,7 +21,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string Topic { get; private set; }
         /// <inheritdoc />
-        public int SlowModeInterval { get; private set; }
+        public virtual int SlowModeInterval { get; private set; }
         /// <inheritdoc />
         public ulong? CategoryId { get; private set; }
         /// <summary>
@@ -33,7 +33,7 @@ namespace Discord.WebSocket
         public ICategoryChannel Category
             => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
         /// <inheritdoc />
-        public Task SyncPermissionsAsync(RequestOptions options = null)
+        public virtual Task SyncPermissionsAsync(RequestOptions options = null)
             => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
         private bool _nsfw;


### PR DESCRIPTION
fix https://github.com/discord-net/Discord.Net/issues/1280

TODO:
- [ ] wait until I can actually test, currently modifying channel type does nothing
- [ ] might need to add special modify async channel props for news channels, since they do not have cooldown, overwrite perms
- [ ] if cooldown, overwrite perms are really not supported, might have to do more work than just making news channels a child class of text channels

blocked. creating a draft PR on my fork just for the diff